### PR TITLE
Improve handling of null values (fix #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.9.1] - 2023-08-18
+
+### Changed
+
+- Improve handling of null values (#13)
+
 ## [0.9.0] - 2023-03-28
 
 ### Changed

--- a/lib/microsoft_kiota_serialization_json/json_parse_node.rb
+++ b/lib/microsoft_kiota_serialization_json/json_parse_node.rb
@@ -49,8 +49,10 @@ module MicrosoftKiotaSerializationJson
     end
 
     def get_collection_of_primitive_values(type)
-      @current_node.map do |x|
-        current_parse_node = JsonParseNode.new(x)
+      @current_node.map do |object|
+        next if object.nil?
+
+        current_parse_node = JsonParseNode.new(object)
         case type
         when String
           current_parse_node.get_string_value
@@ -64,8 +66,8 @@ module MicrosoftKiotaSerializationJson
           current_parse_node.get_date_time_value
         when Time
           current_parse_node.get_time_value
-        when Date 
-          current_parse_node.get_date_value 
+        when Date
+          current_parse_node.get_date_value
         when MicrosoftKiotaAbstractions::ISODuration
           current_parse_node.get_duration_value
         when UUIDTools::UUID
@@ -80,8 +82,10 @@ module MicrosoftKiotaSerializationJson
 
     def get_collection_of_object_values(factory)
       raise StandardError, 'Factory cannot be null' if factory.nil?
-      @current_node.map do |x|
-        current_parse_node = JsonParseNode.new(x)
+      @current_node.map do |object|
+        next if object.nil?
+
+        current_parse_node = JsonParseNode.new(object)
         current_parse_node.get_object_value(factory)
       end
     end
@@ -98,6 +102,8 @@ module MicrosoftKiotaSerializationJson
     def assign_field_values(item)
       fields = item.get_field_deserializers
       @current_node.each do |k, v|
+        next if v.nil?
+
         deserializer = fields[k]
         if deserializer
           deserializer.call(JsonParseNode.new(v))

--- a/lib/microsoft_kiota_serialization_json/version.rb
+++ b/lib/microsoft_kiota_serialization_json/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MicrosoftKiotaSerializationJson
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end

--- a/spec/microsoft_kiota_serialization_json_spec.rb
+++ b/spec/microsoft_kiota_serialization_json_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe MicrosoftKiotaSerializationJson do
     file.close
     message_response = MicrosoftKiotaSerializationJson::JsonParseNodeFactory.new.get_parse_node("application/json", data)
     object_value = message_response.get_object_value(lambda {|pn| Files::MessageCollectionResponse.create_from_discriminator_value(pn)})
-    
+
     ## Object Value tests
     expect(object_value.instance_of? Files::MessageCollectionResponse).to eq(true)
     expect(object_value.value[0].instance_of? Files::Message).to eq(true)
@@ -33,12 +33,12 @@ RSpec.describe MicrosoftKiotaSerializationJson do
     ## String tests
     expect(object_value.odata_next_link.instance_of? String).to eq(true)
     expect(object_value.value[0].body_preview.instance_of? String).to eq(true)
-    
+
     ## Boolean tests
     expect(object_value.value[0].is_draft.to_s.downcase == "true" || object_value.value[0].is_draft.to_s.downcase == "false").to eq(true)
     expect(object_value.value[0].is_read.to_s.downcase == "true" || object_value.value[0].is_read.to_s.downcase == "false").to eq(true)
     expect(object_value.value[0].body_preview.to_s.downcase == "true" || object_value.value[0].body_preview.to_s.downcase == "false").to eq(false)
-    
+
     ## Number tests
     expect(object_value.additional_data["numb"].instance_of? Integer).to eq(true)
 
@@ -46,9 +46,9 @@ RSpec.describe MicrosoftKiotaSerializationJson do
     expect(object_value.value[0].guid_id.instance_of? UUIDTools::UUID).to eq(true)
 
     ## Date tests
-    expect((object_value.value[0].received_date_time).instance_of? DateTime).to eq(true)
+    expect(object_value.value[0].received_date_time).to eq(nil)
     expect((object_value.value[0].sent_date_time).instance_of? DateTime).to eq(true)
-    
+
     ## Collection of Primitive values tests
     expect(object_value.additional_data["primativeValues"].instance_of? Array).to eq(true)
 
@@ -58,7 +58,7 @@ RSpec.describe MicrosoftKiotaSerializationJson do
     ## Enum tests
     expect(object_value.value[0].body.content_type.instance_of? Symbol).to eq(true)
   end
-  
+
   it "can serialize payload" do
     file = File.open("#{File.dirname(__FILE__)}/sample.json")
     data = file.read

--- a/spec/sample.json
+++ b/spec/sample.json
@@ -12,7 +12,7 @@
             "lastModifiedDateTime": "2021-08-02T18:14:38Z",
             "changeKey": "CQAAABYAAABLW5j2RED8SKPe/uUseM8lAAAqleh7",
             "categories": ["cat1", "cat2", "cat3"],
-            "receivedDateTime": "2021-08-02T18:14:37Z",
+            "receivedDateTime": null,
             "sentDateTime": "2021-08-02T18:14:14Z",
             "hasAttachments": false,
             "internetMessageId": "<DM5PR00MB0309A13A7F35E878BDC0233EF2EF9@DM5PR00MB0309.namprd00.prod.outlook.com>",


### PR DESCRIPTION
Those changes improve the handling of null values for both payload and object collection deserialization. 

It simply skips trying to parsing them as it would fail or return incorrect values.

This fixes the issue reported in #8 and I can now get a group response with a null value for ex. `deleted_at_time`:

![image](https://github.com/microsoft/kiota-serialization-json-ruby/assets/143380/8a1a46f1-4dc0-45c7-8c82-0801708fac45)

From my understanding, the tests do not cover yet the `get_collection_of_primitive_values` and `get_collection_of_object_values` method although they are used in the ruby SDK. I think the same fix needs to be applied (and I did). But it would probably be nice to add tests for them but I don't have extra bandwidth to investigate that  at this time.

Note: my editor also stripped some random extra spaces (I think it is better without them 🧹).

Best regards 👋 