### PR TITLE
fix enum value serializer

### DIFF
--- a/lib/microsoft_kiota_serialization_json/json_serialization_writer.rb
+++ b/lib/microsoft_kiota_serialization_json/json_serialization_writer.rb
@@ -174,8 +174,8 @@ module MicrosoftKiotaSerializationJson
       end
     end
 
-    def write_enum_value(key, values)
-      self.write_string_value(key, values.to_s)
+    def write_enum_value(key, value)
+      self.write_string_value(key, value)
     end
 
     def get_serialized_content()


### PR DESCRIPTION
The current behaviour transforms a nil into a string before passing it into the `write_string_value` method.

That means that default value get an empty string. Looking at the documentation Enums are strings and not a list of values.

https://github.com/microsoft/kiota/pull/4146