### PR TITLE
feat: upgrade ruby CI matrix to 3.3, 3.4 and 4.0

### DIFF
--- a/.github/policies/kiota-serialization-json-ruby-branch-protection.yml
+++ b/.github/policies/kiota-serialization-json-ruby-branch-protection.yml
@@ -1,0 +1,40 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: kiota-serialization-json-ruby-branch-protection
+description: Branch protection policy for the kiota-serialization-json-ruby repository
+resource: repository
+configuration:
+  branchProtectionRules:
+
+    - branchNamePattern: main
+      # Specifies whether this branch can be deleted. boolean
+      allowsDeletions: false
+      # Specifies whether forced pushes are allowed on this branch. boolean
+      allowsForcePushes: false
+      # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
+      dismissStaleReviews: true
+      # Specifies whether admins can overwrite branch protection. boolean
+      isAdminEnforced: false
+      # Indicates whether "Require a pull request before merging" is enabled. boolean
+      requiresPullRequestBeforeMerging: true
+      # Specifies the number of pull request reviews before merging. int (0-6). Should be null/empty if PRs are not required
+      requiredApprovingReviewsCount: 1
+      # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
+      requireCodeOwnersReview: true
+      # Are commits required to be signed. boolean
+      requiresCommitSignatures: false
+      # Are conversations required to be resolved before merging? boolean
+      requiresConversationResolution: true
+      # Are merge commits prohibited from being pushed to this branch. boolean
+      requiresLinearHistory: false
+      # Required status checks to pass before merging
+      requiredStatusChecks:
+        - license/cla
+        - check-ruby-version-matrix
+      # Require branches to be up to date before merging. boolean
+      requiresStrictStatusChecks: false
+      # Indicates whether there are restrictions on who can push. boolean
+      restrictsPushes: false
+      # Restrict who can dismiss pull request reviews. boolean
+      restrictsReviewDismissals: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{ github.ref }}
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.4'
           bundler-cache: true
           bundler: 'latest'
           cache-version: 1

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby-version: ['3.0', '3.1', '3.2', head, jruby, jruby-head, truffleruby, truffleruby-head]
+        ruby-version: ['3.3', '3.4', '4.0', head, jruby, jruby-head, truffleruby, truffleruby-head]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -25,10 +25,24 @@ jobs:
       - name: Run tests
         run: bundle exec rake
       - name: Upload artifacts for ruby version 3 and ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest'  && matrix.ruby-version == '3.2'}}
+        if: ${{ matrix.os == 'ubuntu-latest'  && matrix.ruby-version == '3.4'}}
         uses: actions/upload-artifact@v7
         with:
           name: drop
           path: |
             ./Gemfile.lock
             ./README.md
+
+  # The check-ruby-version-matrix returns success if all matrix jobs in build are successful; otherwise, it returns a failure.
+  # Use this as a PR status check for GitHub Policy Service instead of individual matrix entry checks.
+  check-ruby-version-matrix:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: always()
+    steps:
+      - name: All build matrix options are successful
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: One or more build matrix options failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
Remove unmaintained Ruby 3.0, 3.1, and 3.2 from the CI matrix and
add Ruby 3.3, 3.4, and 4.0. Update artifact upload condition to
use Ruby 3.4.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
